### PR TITLE
Check for .swiftlint.yml when determining working directory

### DIFF
--- a/flycheck-swiftlint.el
+++ b/flycheck-swiftlint.el
@@ -98,6 +98,7 @@
 (defun flycheck-swiftlint--find-swiftlint-directory ()
   "Return directory for use with Swiftlint."
   (or
+   (locate-dominating-file buffer-file-name ".swiftlint.yml")
    (locate-dominating-file buffer-file-name ".git")
    (flycheck-swiftlint--find-xcodeproj-directory)))
 


### PR DESCRIPTION
SwiftLint supports a .swiftlint.yml configuration file which can be placed in
the directory you run SwiftLint from. It makes sense then to check for it and
use that as the working directory if it exists.

I'm using this change locally and it seems to do what I want it to.